### PR TITLE
Remove deprecated rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -121,7 +121,6 @@
     "no-multi-spaces": "error",
     "no-multi-str": "error",
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0 }],
-    "no-negated-in-lhs": "error",
     "no-new": "error",
     "no-new-func": "error",
     "no-new-object": "error",


### PR DESCRIPTION
<!--
  Proposing a new rule or a rule change? Please open an issue here first:
  https://github.com/standard/standard/issues
  
  If the rule has been accepted and you want to send a PR, please send it
  to: https://github.com/standard/standard. Add the rule to the
  'eslintrc.json' file, in the "rules" field. This is where rules live
  until a new major version of standard is released, at which point all
  new rules and rule changes are moved into eslint-config-standard.
-->
As per https://eslint.org/docs/rules/no-negated-in-lhs , `no-negated-in-lhs` was replaced by [`no-unsafe-negation`](https://eslint.org/docs/rules/no-unsafe-negation), which you already have (as `"no-unsafe-negation": "error"`).

(Noticed this while introspecting on a derivative config object.)